### PR TITLE
feat: implement tyranno sync CLI command with expression evaluator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dependencies = [
   "platformdirs>=4.10",
   "pathspec>=1.1",
   "jsonpath-ng>=1.8",
+  "pyyaml>=6.0",
   "semver>=3.0.4",
   # /usr/share/zoneinfo uses IANA zones; Windows does not
   # OR `"tzdata>=2026.1; platform_system == 'Windows'",`

--- a/src/tyranno_sandbox/__main__.py
+++ b/src/tyranno_sandbox/__main__.py
@@ -16,13 +16,15 @@ from typing import Annotated, Final, Self, TextIO
 
 import click
 import typer
+from click import Context as ClickContext
 from click import Parameter
 from loguru import logger
 from typer import Argument, Option, Typer
 
 from tyranno_sandbox._about import __about__
 from tyranno_sandbox._global_vars import EnvGlobalVarsFactory, GlobalVars
-from tyranno_sandbox.context import Context, ContextFactory, DefaultContextFactory
+from tyranno_sandbox.context import ContextFactory, DefaultContextFactory
+from tyranno_sandbox.sync import Syncer
 
 ENV: GlobalVars = EnvGlobalVarsFactory(env=os.environ)()
 
@@ -36,7 +38,7 @@ class SpdxLicense(Enum):
     MPL = "MPL-2.0"
 
 
-class LogLevel(Enum):
+class LogLevel(int, Enum):
     """Default loguru log levels, except for CRITICAL."""
 
     TRACE = 5
@@ -49,7 +51,7 @@ class LogLevel(Enum):
     @classmethod
     def by_index(cls, i: int, *, clamp: bool = False) -> Self:
         if clamp:
-            i = max(len(cls) - 1, min(0, i))
+            i = min(len(cls) - 1, max(0, i))
         return list(cls)[i]
 
 
@@ -93,12 +95,13 @@ class Logging:
 
     # ruff: noqa: A001, A002
     def configure(self, *, quiet: int, verbose: int, to: str, format: str) -> None:
-        index = LogLevel.SUCCESS.value + quiet - verbose
+        success_index = list(LogLevel).index(LogLevel.SUCCESS)
+        index = success_index + quiet - verbose
         self.level = LogLevel.by_index(index, clamp=True)
         logger.remove()
         sink = LogSink.of(to).sink
         format = format or self._default_fmt()
-        logger.add(sink=sink, level=self.level.name, format=format, encoding="utf-8")
+        logger.add(sink=sink, level=self.level.name, format=format)
 
     def _default_fmt(self) -> str:
         if self.level is LogLevel.TRACE:
@@ -120,7 +123,7 @@ class Inode(click.Path):
         #   Override to prevent passing arguments.
         super().__init__()
 
-    def convert(self, value: str, param: Parameter, ctx: Context) -> Path:
+    def convert(self, value: str, param: Parameter, ctx: ClickContext) -> Path:
         path = self.resolve(Path(super().convert(value, param, ctx)))
         try:
             mode: int = path.stat(follow_symlinks=False).st_mode
@@ -241,7 +244,10 @@ def new(
 def sync() -> None:
     """Syncs project metadata between configured files."""
     logger.info("Syncing metadata...")
-    logger.info("␣")
+    context = state.create_context()
+    syncer = Syncer(context)
+    syncer.run()
+    logger.success("Sync complete.")
 
 
 if __name__ == "__main__":

--- a/src/tyranno_sandbox/_global_vars.py
+++ b/src/tyranno_sandbox/_global_vars.py
@@ -4,7 +4,6 @@
 
 """Environment variables and internal utils."""
 
-import sys
 import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
@@ -62,7 +61,6 @@ class GlobalVars:
     data_dir: Path
     log_dir: Path
     tyranno_dir: str
-    use_color: bool
     log_format: str
     debug_mode: bool
 
@@ -124,20 +122,10 @@ class EnvGlobalVarsFactory(GlobalVarsFactory):
             config_dir=xdg.dir(platformdirs.user_config_dir),
             data_dir=xdg.dir(platformdirs.user_data_dir),
             log_dir=xdg.dir(platformdirs.user_log_dir),
-            use_color=self._use_color(),
             tyranno_dir=str(self._rel_dir("TYRANNO_DIR", Path(".tyranno"))),
             log_format=self._str("TYRANNO_LOG_FORMAT", ""),
             debug_mode=self._flag("TYRANNO_DEBUG_MODE"),
         )
-
-    def _use_color(self) -> bool:
-        # See https://force-color.org/ and https://no-color.org/
-        if self._flag("FORCE_COLOR"):
-            return True
-        no_color = self.env.get("NO_COLOR")
-        if no_color is not None and no_color not in {"", "0"}:
-            return False
-        return sys.stdout.isatty()
 
     def _str(self, var: str, default: str) -> str:
         return self.env.get(var, default)

--- a/src/tyranno_sandbox/_global_vars.py
+++ b/src/tyranno_sandbox/_global_vars.py
@@ -46,6 +46,13 @@ class Startup:
         return time.monotonic() - self.monotonic
 
 
+class GlobalVarsFactory:
+    """Factory that creates a [GlobalVars][] instance."""
+
+    def __call__(self) -> GlobalVars:
+        raise NotImplementedError
+
+
 @dataclass(frozen=True, slots=True, kw_only=True)
 class GlobalVars:
     """Collection of config values from environment variables and/or the platform."""
@@ -100,13 +107,12 @@ class XdgHelper[**P]:
             "appname": __about__["name"],
             "appauthor": __about__["vendor"],
             "version": str(__about__["version_parts"].major),
-            "roaming": False,
             "ensure_exists": False,
         }
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
-class EnvGlobalVarsFactory(Callable[[], GlobalVars]):
+class EnvGlobalVarsFactory(GlobalVarsFactory):
     """Factory that reads from environment variables and platform config."""
 
     env: Mapping[str, str | None]
@@ -125,8 +131,13 @@ class EnvGlobalVarsFactory(Callable[[], GlobalVars]):
         )
 
     def _use_color(self) -> bool:
-        # See https://force-color.org/) and https://no-color.org/
-        return self._flag("FORCE_COLOR", self._flag("NO_COLOR", sys.stdout.isatty()))
+        # See https://force-color.org/ and https://no-color.org/
+        if self._flag("FORCE_COLOR"):
+            return True
+        no_color = self.env.get("NO_COLOR")
+        if no_color is not None and no_color not in {"", "0"}:
+            return False
+        return sys.stdout.isatty()
 
     def _str(self, var: str, default: str) -> str:
         return self.env.get(var, default)

--- a/src/tyranno_sandbox/context.py
+++ b/src/tyranno_sandbox/context.py
@@ -7,10 +7,10 @@
 import re
 import tomllib
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
-import jsonpath
 from pathspec import GitIgnoreSpec
 
 from tyranno_sandbox.dot_tree import DotTree, Toml
@@ -21,9 +21,20 @@ if TYPE_CHECKING:
     from tyranno_sandbox._global_vars import GlobalVars
 
 __all__ = ["Context", "ContextFactory", "Data", "DefaultContextFactory"]
-SIMPLE_KEY_REGEX: Final = re.compile(r"([A-Za-z_][A-Za-z0-9_-]*+)(\.([A-Za-z_][A-Za-z0-9_-]*+))*+")
-# Match `${{group1}}` using a possessive `[^}]++` and `}` with a negative lookahead.
-EXPR_REGEX: Final = re.compile(r"\$\{\{ (?P<expr>(?: [^}]++ | }(?!}) )*) }}", re.VERBOSE)
+
+# Match simple dotted key names like `project.name` or `tool.tyranno.data.vendor`
+SIMPLE_KEY_REGEX: Final = re.compile(
+    r"[A-Za-z_][A-Za-z0-9_-]*+(?:\.[A-Za-z_][A-Za-z0-9_-]*+)*+"
+)
+
+# Match `$<<expr>>` using a non-greedy inner pattern
+EXPR_REGEX: Final = re.compile(r"\$<<(?P<expr>.*?)>>", re.DOTALL)
+
+# Match a function call: name(args...)
+_FUNC_CALL_RE: Final = re.compile(r"([a-zA-Z_][a-zA-Z0-9_]*)\(([^)]*)\)$")
+
+# Split a pipe chain:  a | b | c
+_PIPE_SPLIT_RE: Final = re.compile(r"\s*\|\s*")
 
 
 @dataclass(frozen=True, slots=True)
@@ -39,21 +50,214 @@ class Data:
         return self.tree.access(key)
 
     def replace_vars_in(self, template: str, *, in_key: str = "") -> str:
-        def xyz(m: re.Match) -> str:
+        def _expand(m: re.Match) -> str:
             return self.expand_var(m.group("expr"), in_key=in_key)
 
-        return EXPR_REGEX.sub(xyz, template)
+        return EXPR_REGEX.sub(_expand, template)
+
+    # ------------------------------------------------------------------
+    # Expression evaluation
+    # ------------------------------------------------------------------
 
     def expand_var(self, expression: str, *, in_key: str = "") -> str:
+        """Evaluate a single expression from inside ``$<< >>``.
+
+        Handles:
+        - Simple key paths: ``project.name``, ``.vendor``
+        - Pipe syntax:  ``project.keywords | yaml(@)``
+        - Chained functions: ``project.description.yaml(@)``
+        - Standalone calls: ``now_utc().year``
+        """
         expression = expression.strip()
-        if expression.startswith("~."):
-            expression = "tool.tyranno.data" + expression
-        if in_key and expression.startswith("."):
-            expression = in_key + expression
-        if SIMPLE_KEY_REGEX.fullmatch(expression):
-            return self.tree.access(expression)
-        # TODO
-        return jsonpath.compile(expression).search(self.tree, self._jsonpath_options)
+        if not expression:
+            return ""
+
+        # Pipe syntax: split on | and process left-to-right
+        if "|" in expression:
+            parts = _PIPE_SPLIT_RE.split(expression)
+            value = self._resolve_key(parts[0].strip(), in_key=in_key)
+            for func_call in parts[1:]:
+                value = self._apply_func(func_call.strip(), value)
+            return value
+
+        # Compact dot-chained syntax: project.description.yaml(@)
+        # Split into key path + trailing function calls
+        key_part, func_calls = self._parse_chained(expression, in_key=in_key)
+
+        # If key_part is empty the whole expression is a standalone function chain
+        # (e.g. "now_utc().year") — reconstruct and evaluate directly.
+        if not key_part and func_calls:
+            return self._resolve_key(".".join(func_calls), in_key=in_key)
+
+        value = self._resolve_key(key_part, in_key=in_key)
+        for fc in func_calls:
+            value = self._apply_func(fc, value)
+        return value
+
+    def _parse_chained(self, expr: str, *, in_key: str = "") -> tuple[str, list[str]]:
+        """Split ``key.func1(args).func2(args)`` into key + function list."""
+        # Collapse spaces in "$ .project .name" style
+        if re.search(r"\s", expr):
+            expr = re.sub(r"\s*\.\s*", ".", re.sub(r"\s+", " ", expr)).strip()
+
+        # Walk dot-segments left to right; once a segment has "(" it's a func call
+        segments = expr.split(".")
+        key_segs: list[str] = []
+        func_calls: list[str] = []
+        in_funcs = False
+        for seg in segments:
+            if in_funcs or ("(" in seg):
+                if seg:
+                    func_calls.append(seg)
+                in_funcs = True
+            else:
+                key_segs.append(seg)
+
+        # Keep empty leading string so that ".frag" → key ".frag", not "frag"
+        return ".".join(key_segs), func_calls
+
+    def _resolve_key(self, expr: str, *, in_key: str = "") -> str:
+        """Resolve a key expression (no function calls) to a string value."""
+        expr = expr.strip()
+        if not expr:
+            return ""
+
+        # Standalone function call: now_utc().year  /  now_local()
+        if "(" in expr:
+            return self._eval_standalone(expr)
+
+        # Strip file-local marker
+        if expr.startswith("^"):
+            expr = expr[1:]
+
+        # Normalise prefix to a plain dotted key
+        if expr.startswith("$."):
+            simple_key = expr[2:]
+        elif expr.startswith("@."):
+            simple_key = "tool.tyranno.data." + expr[2:]
+        elif expr.startswith("."):
+            simple_key = (in_key + expr) if in_key else ("tool.tyranno.data" + expr)
+        elif expr == "$":
+            return ""
+        else:
+            simple_key = expr
+
+        # Fast path: plain dotted key
+        if SIMPLE_KEY_REGEX.fullmatch(simple_key):
+            try:
+                value = self.tree.access(simple_key)
+                return self._to_str(value)
+            except (KeyError, TypeError):
+                pass
+
+        # Fallback: JSONPath via jsonpath_ng
+        try:
+            from jsonpath_ng import parse as jsonpath_parse  # noqa: PLC0415
+
+            jpath = expr if expr.startswith("$") else f"$.{simple_key}"
+            matches = jsonpath_parse(jpath).find(dict(self.tree))
+            if matches:
+                return self._to_str(matches[0].value)
+        except Exception:  # noqa: BLE001
+            pass
+
+        return f"<unresolved:{expr}>"
+
+    def _eval_standalone(self, expr: str) -> str:
+        """Evaluate a standalone function call expression like ``now_utc().year``."""
+        # now_utc() and now_local() return a dict-like with year/month/day etc.
+        now_utc = datetime.now(UTC)
+        now_local = datetime.now().astimezone()
+
+        known: dict[str, object] = {
+            "now_utc()": now_utc,
+            "now_local()": now_local,
+        }
+        # Check for attribute access: now_utc().year
+        for prefix, dt_obj in known.items():
+            if expr.startswith(prefix):
+                rest = expr[len(prefix):]
+                if rest.startswith("."):
+                    attr = rest[1:]
+                    return str(getattr(dt_obj, attr, f"<no attr {attr}>"))
+                if not rest:
+                    return str(dt_obj)
+        return f"<unresolved:{expr}>"
+
+    @staticmethod
+    def _apply_func(func_call: str, value: str) -> str:
+        """Apply a single function call like ``yaml(@)`` to ``value``."""
+        func_call = func_call.strip()
+        m = _FUNC_CALL_RE.fullmatch(func_call)
+        if not m:
+            return value
+
+        name = m.group(1)
+        raw_args = [a.strip() for a in m.group(2).split(",") if a.strip()]
+        # Replace @ with the current value in positional args
+        args = [value if a == "@" else a.strip("'\"") for a in raw_args]
+
+        match name:
+            case "yaml":
+                return Data._yaml_scalar(value)
+            case "yaml_multiline":
+                indent = int(args[1]) if len(args) > 1 else 0
+                return Data._yaml_seq_multiline(value, indent)
+            case "lower":
+                return value.lower()
+            case "upper":
+                return value.upper()
+            case "replace":
+                # replace(@, old, new) — args[0] is @ (value), [1] is old, [2] is new
+                if len(args) >= 3:  # noqa: PLR2004
+                    return args[0].replace(args[1], args[2])
+            case "spdx_license":
+                # Return the SPDX identifier itself — license data lookup is unimplemented
+                return value
+            case "pep440_minor":
+                try:
+                    from packaging.version import Version  # noqa: PLC0415
+
+                    v = Version(value)
+                    return f"{v.major}.{v.minor}"
+                except Exception:  # noqa: BLE001
+                    return value
+            case "sort":
+                items = [i.strip() for i in value.split(",")]
+                return ", ".join(sorted(items))
+            case "join":
+                # join(sep, @) — args[0] is sep, args[1] is @ (value)
+                sep = args[0] if args else ", "
+                items = [i.strip() for i in value.split(",")]
+                return sep.join(items)
+        return value
+
+    @staticmethod
+    def _yaml_scalar(value: str) -> str:
+        """Quote a string as a YAML scalar if necessary."""
+        needs_quoting = (
+            not value
+            or value[0] in "#&*?|->!%@`'\""
+            or any(c in value for c in ":#\n{[")
+            or value.lower() in {"true", "false", "null", "yes", "no", "on", "off"}
+        )
+        if needs_quoting:
+            escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+            return f'"{escaped}"'
+        return value
+
+    @staticmethod
+    def _yaml_seq_multiline(value: str, indent: int = 0) -> str:
+        """Format a comma-separated value as an indented YAML sequence block."""
+        pad = " " * indent
+        items = [v.strip() for v in value.split(",") if v.strip()]
+        return "\n".join(f'{pad}"{item}"' for item in items)
+
+    @staticmethod
+    def _to_str(value: Toml) -> str:
+        if isinstance(value, list):
+            return ", ".join(str(v) for v in value)
+        return str(value)
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -66,10 +270,10 @@ class Context:
     dry_run: bool
 
     def bak_path(self, path: Path) -> Path:
-        return self.bak_dir / path.parent.relative_to(self.repo_dir)
+        return self.bak_dir / path.relative_to(self.repo_dir)
 
     def trash_path(self, path: Path) -> Path:
-        return self.trash_dir / path.parent.relative_to(self.repo_dir)
+        return self.trash_dir / path.relative_to(self.repo_dir)
 
     @property
     def bak_dir(self) -> Path:
@@ -80,22 +284,16 @@ class Context:
         return self.repo_dir / self.env.tyranno_dir / "trashed"
 
     def find_targets(self) -> Iterator[Path]:
-        include = self.data.tree.access_subtree("tool.tyranno.targets")
+        include = self.data.tree.get_list_as("tool.tyranno.targets", as_type=str)
         target_spec = GitIgnoreSpec.from_lines(include)
         gitignore_spec = self._gitignore_spec()
-        for p in target_spec.match_tree(self.repo_dir):
+        for p in target_spec.match_tree_files(str(self.repo_dir)):
             if not gitignore_spec.match_file(p):
-                yield self.resolve_path(p)
-
-    def resolve_path(self, path: Path | str) -> Path:
-        path = Path(path).resolve(strict=True)
-        if not str(path).startswith(str(self.repo_dir)):
-            msg = f"{path} is not a descendent of {self.repo_dir}"
-            raise AssertionError(msg)
-        return path.relative_to(self.repo_dir)
+                yield self.repo_dir / p
 
     def _gitignore_spec(self) -> GitIgnoreSpec:
-        lines = (self.repo_dir / ".gitignore").read_text().splitlines()
+        gitignore = self.repo_dir / ".gitignore"
+        lines = gitignore.read_text(encoding="utf-8").splitlines() if gitignore.exists() else []
         return GitIgnoreSpec.from_lines(lines)
 
 
@@ -111,6 +309,6 @@ class DefaultContextFactory(ContextFactory):
     """A [Context][] factory that reads from `pyproject.toml`."""
 
     def __call__(self, cwd: Path, env: GlobalVars, *, dry_run: bool) -> Context:
-        read = Path("pyproject.toml").read_text(encoding="utf-8")
+        read = (cwd / "pyproject.toml").read_text(encoding="utf-8")
         tree = DotTree.from_nested(tomllib.loads(read))
         return Context(env=env, repo_dir=cwd, data=Data(tree), dry_run=dry_run)

--- a/src/tyranno_sandbox/context.py
+++ b/src/tyranno_sandbox/context.py
@@ -7,20 +7,23 @@
 import re
 import tomllib
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Any, Final
 
+from jsonpath_ng import parse as jsonpath_parse
 from pathspec import GitIgnoreSpec
 
 from tyranno_sandbox.dot_tree import DotTree, Toml
+from tyranno_sandbox.tyranno_functions import FUNCS, SOURCE_FUNCS
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from tyranno_sandbox._global_vars import GlobalVars
 
-__all__ = ["Context", "ContextFactory", "Data", "DefaultContextFactory"]
+__all__ = ["Context", "ContextFactory", "Data", "DefaultContextFactory", "ExpressionError"]
+
+# ── Regex patterns (all pre-compiled) ────────────────────────────────────────
 
 # Match simple dotted key names like `project.name` or `tool.tyranno.data.vendor`
 SIMPLE_KEY_REGEX: Final = re.compile(
@@ -35,6 +38,22 @@ _FUNC_CALL_RE: Final = re.compile(r"([a-zA-Z_][a-zA-Z0-9_]*)\(([^)]*)\)$")
 
 # Split a pipe chain:  a | b | c
 _PIPE_SPLIT_RE: Final = re.compile(r"\s*\|\s*")
+
+# Collapse whitespace around dots for spaced key notation:  "$ .project .name"
+_WS_DOT_RE: Final = re.compile(r"\s*\.\s*")
+_MULTI_SPACE_RE: Final = re.compile(r"\s+")
+
+# ── Key prefix constants ──────────────────────────────────────────────────────
+
+_PREFIX_ROOT: Final = "$."       # $.key → pyproject root key
+_PREFIX_AT: Final = "@."         # @.key → tool.tyranno.data.key
+_PREFIX_LOCAL: Final = "."       # .key → relative to in_key context
+_ROOT_ONLY: Final = "$"          # bare "$" → empty string
+_MARKER_FILE_LOCAL: Final = "^"  # ^key → strip this marker (file-local reference)
+
+
+class ExpressionError(Exception):
+    """Raised when a Tyranno template expression cannot be evaluated."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -63,10 +82,10 @@ class Data:
         """Evaluate a single expression from inside ``$<< >>``.
 
         Handles:
-        - Simple key paths: ``project.name``, ``.vendor``
-        - Pipe syntax:  ``project.keywords | yaml(@)``
-        - Chained functions: ``project.description.yaml(@)``
-        - Standalone calls: ``now_utc().year``
+        - Simple key paths: `project.name`, `.vendor`
+        - Pipe syntax: `project.keywords | yaml(@)`
+        - Chained functions: `project.description | yaml(@)`
+        - Standalone calls: `now_utc().year`
         """
         expression = expression.strip()
         if not expression:
@@ -75,32 +94,26 @@ class Data:
         # Pipe syntax: split on | and process left-to-right
         if "|" in expression:
             parts = _PIPE_SPLIT_RE.split(expression)
-            value = self._resolve_key(parts[0].strip(), in_key=in_key)
+            first = parts[0].strip()
+            value: Any = (
+                self._apply_func(first, None) if "(" in first else self._resolve_key(first, in_key=in_key)
+            )
             for func_call in parts[1:]:
                 value = self._apply_func(func_call.strip(), value)
-            return value
+            return self._to_str(value)
 
-        # Compact dot-chained syntax: project.description.yaml(@)
-        # Split into key path + trailing function calls
-        key_part, func_calls = self._parse_chained(expression, in_key=in_key)
-
-        # If key_part is empty the whole expression is a standalone function chain
-        # (e.g. "now_utc().year") — reconstruct and evaluate directly.
-        if not key_part and func_calls:
-            return self._resolve_key(".".join(func_calls), in_key=in_key)
-
-        value = self._resolve_key(key_part, in_key=in_key)
+        # Compact dot-chained syntax: key.func1(args).func2(args)
+        key_part, func_calls = self._parse_chained(expression)
+        value = None if not key_part else self._resolve_key(key_part, in_key=in_key)
         for fc in func_calls:
             value = self._apply_func(fc, value)
-        return value
+        return self._to_str(value) if value is not None else ""
 
-    def _parse_chained(self, expr: str, *, in_key: str = "") -> tuple[str, list[str]]:
-        """Split ``key.func1(args).func2(args)`` into key + function list."""
-        # Collapse spaces in "$ .project .name" style
+    def _parse_chained(self, expr: str) -> tuple[str, list[str]]:
+        """Split `key.func1(args).func2(args)` into a key path and function list."""
         if re.search(r"\s", expr):
-            expr = re.sub(r"\s*\.\s*", ".", re.sub(r"\s+", " ", expr)).strip()
+            expr = _WS_DOT_RE.sub(".", _MULTI_SPACE_RE.sub(" ", expr)).strip()
 
-        # Walk dot-segments left to right; once a segment has "(" it's a func call
         segments = expr.split(".")
         key_segs: list[str] = []
         func_calls: list[str] = []
@@ -113,148 +126,62 @@ class Data:
             else:
                 key_segs.append(seg)
 
-        # Keep empty leading string so that ".frag" → key ".frag", not "frag"
+        # Preserve empty leading element so `.frag` → `".frag"` not `"frag"`
         return ".".join(key_segs), func_calls
 
-    def _resolve_key(self, expr: str, *, in_key: str = "") -> str:
-        """Resolve a key expression (no function calls) to a string value."""
+    def _resolve_key(self, expr: str, *, in_key: str = "") -> Any:
+        """Resolve a dotted key expression to its raw value in the tree."""
         expr = expr.strip()
         if not expr:
             return ""
 
-        # Standalone function call: now_utc().year  /  now_local()
-        if "(" in expr:
-            return self._eval_standalone(expr)
-
-        # Strip file-local marker
-        if expr.startswith("^"):
-            expr = expr[1:]
-
-        # Normalise prefix to a plain dotted key
-        if expr.startswith("$."):
+        if expr.startswith(_PREFIX_ROOT):
             simple_key = expr[2:]
-        elif expr.startswith("@."):
+        elif expr.startswith(_PREFIX_AT):
             simple_key = "tool.tyranno.data." + expr[2:]
-        elif expr.startswith("."):
+        elif expr.startswith(_PREFIX_LOCAL):
             simple_key = (in_key + expr) if in_key else ("tool.tyranno.data" + expr)
-        elif expr == "$":
+        elif expr == _ROOT_ONLY:
             return ""
         else:
-            simple_key = expr
+            simple_key = expr.removeprefix(_MARKER_FILE_LOCAL)
 
-        # Fast path: plain dotted key
         if SIMPLE_KEY_REGEX.fullmatch(simple_key):
             try:
-                value = self.tree.access(simple_key)
-                return self._to_str(value)
-            except (KeyError, TypeError):
-                pass
+                return self.tree.access(simple_key)
+            except (KeyError, TypeError) as e:
+                raise ExpressionError(f"Key not found: {simple_key!r}") from e
 
-        # Fallback: JSONPath via jsonpath_ng
+        jpath = expr if expr.startswith("$") else f"$.{simple_key}"
         try:
-            from jsonpath_ng import parse as jsonpath_parse  # noqa: PLC0415
-
-            jpath = expr if expr.startswith("$") else f"$.{simple_key}"
             matches = jsonpath_parse(jpath).find(dict(self.tree))
             if matches:
-                return self._to_str(matches[0].value)
-        except Exception:  # noqa: BLE001
-            pass
+                return matches[0].value
+        except Exception as e:
+            raise ExpressionError(f"Key not found: {expr!r}") from e
+        raise ExpressionError(f"Key not found: {expr!r}")
 
-        return f"<unresolved:{expr}>"
-
-    def _eval_standalone(self, expr: str) -> str:
-        """Evaluate a standalone function call expression like ``now_utc().year``."""
-        # now_utc() and now_local() return a dict-like with year/month/day etc.
-        now_utc = datetime.now(UTC)
-        now_local = datetime.now().astimezone()
-
-        known: dict[str, object] = {
-            "now_utc()": now_utc,
-            "now_local()": now_local,
-        }
-        # Check for attribute access: now_utc().year
-        for prefix, dt_obj in known.items():
-            if expr.startswith(prefix):
-                rest = expr[len(prefix):]
-                if rest.startswith("."):
-                    attr = rest[1:]
-                    return str(getattr(dt_obj, attr, f"<no attr {attr}>"))
-                if not rest:
-                    return str(dt_obj)
-        return f"<unresolved:{expr}>"
-
-    @staticmethod
-    def _apply_func(func_call: str, value: str) -> str:
-        """Apply a single function call like ``yaml(@)`` to ``value``."""
+    def _apply_func(self, func_call: str, value: Any) -> Any:
+        """Apply a single function call like `yaml(@)` or attribute access like `year`."""
         func_call = func_call.strip()
-        m = _FUNC_CALL_RE.fullmatch(func_call)
-        if not m:
-            return value
-
-        name = m.group(1)
-        raw_args = [a.strip() for a in m.group(2).split(",") if a.strip()]
-        # Replace @ with the current value in positional args
-        args = [value if a == "@" else a.strip("'\"") for a in raw_args]
-
-        match name:
-            case "yaml":
-                return Data._yaml_scalar(value)
-            case "yaml_multiline":
-                indent = int(args[1]) if len(args) > 1 else 0
-                return Data._yaml_seq_multiline(value, indent)
-            case "lower":
-                return value.lower()
-            case "upper":
-                return value.upper()
-            case "replace":
-                # replace(@, old, new) — args[0] is @ (value), [1] is old, [2] is new
-                if len(args) >= 3:  # noqa: PLR2004
-                    return args[0].replace(args[1], args[2])
-            case "spdx_license":
-                # Return the SPDX identifier itself — license data lookup is unimplemented
-                return value
-            case "pep440_minor":
-                try:
-                    from packaging.version import Version  # noqa: PLC0415
-
-                    v = Version(value)
-                    return f"{v.major}.{v.minor}"
-                except Exception:  # noqa: BLE001
-                    return value
-            case "sort":
-                items = [i.strip() for i in value.split(",")]
-                return ", ".join(sorted(items))
-            case "join":
-                # join(sep, @) — args[0] is sep, args[1] is @ (value)
-                sep = args[0] if args else ", "
-                items = [i.strip() for i in value.split(",")]
-                return sep.join(items)
-        return value
+        if m := _FUNC_CALL_RE.fullmatch(func_call):
+            name = m.group(1)
+            raw_args = [a.strip() for a in m.group(2).split(",") if a.strip()]
+            # `@` is the value placeholder; strip it — value is always passed as first arg
+            extra_args = [a.strip("'\"") for a in raw_args if a != "@"]
+            if name in SOURCE_FUNCS:
+                return SOURCE_FUNCS[name](*extra_args)
+            if name in FUNCS:
+                return FUNCS[name](value, *extra_args)
+            raise ExpressionError(f"Unknown function: {name!r}")
+        # No parentheses: treat as attribute access on the current value
+        try:
+            return getattr(value, func_call)
+        except AttributeError:
+            raise ExpressionError(f"No attribute {func_call!r} on {type(value).__name__}")
 
     @staticmethod
-    def _yaml_scalar(value: str) -> str:
-        """Quote a string as a YAML scalar if necessary."""
-        needs_quoting = (
-            not value
-            or value[0] in "#&*?|->!%@`'\""
-            or any(c in value for c in ":#\n{[")
-            or value.lower() in {"true", "false", "null", "yes", "no", "on", "off"}
-        )
-        if needs_quoting:
-            escaped = value.replace("\\", "\\\\").replace('"', '\\"')
-            return f'"{escaped}"'
-        return value
-
-    @staticmethod
-    def _yaml_seq_multiline(value: str, indent: int = 0) -> str:
-        """Format a comma-separated value as an indented YAML sequence block."""
-        pad = " " * indent
-        items = [v.strip() for v in value.split(",") if v.strip()]
-        return "\n".join(f'{pad}"{item}"' for item in items)
-
-    @staticmethod
-    def _to_str(value: Toml) -> str:
+    def _to_str(value: Any) -> str:
         if isinstance(value, list):
             return ", ".join(str(v) for v in value)
         return str(value)

--- a/src/tyranno_sandbox/context.py
+++ b/src/tyranno_sandbox/context.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final
 
-from jsonpath_ng import parse as jsonpath_parse
+from jsonpath_ng.ext import parse as jsonpath_parse
 from pathspec import GitIgnoreSpec
 
 from tyranno_sandbox.dot_tree import DotTree, Toml
@@ -21,7 +21,20 @@ if TYPE_CHECKING:
 
     from tyranno_sandbox._global_vars import GlobalVars
 
-__all__ = ["Context", "ContextFactory", "Data", "DefaultContextFactory", "ExpressionError"]
+__all__ = [
+    "CommentSyntaxError",
+    "Context",
+    "ContextFactory",
+    "Data",
+    "DefaultContextFactory",
+    "ErrorLocation",
+    "ExpressionError",
+    "FunctionFailedError",
+    "NoSuchFunctionError",
+    "NoSuchKeyError",
+    "SignatureMismatchError",
+    "SyncError",
+]
 
 # ── Regex patterns (all pre-compiled) ────────────────────────────────────────
 
@@ -43,6 +56,9 @@ _PIPE_SPLIT_RE: Final = re.compile(r"\s*\|\s*")
 _WS_DOT_RE: Final = re.compile(r"\s*\.\s*")
 _MULTI_SPACE_RE: Final = re.compile(r"\s+")
 
+# Detect any whitespace in an expression
+_WS_CHECK_RE: Final = re.compile(r"\s")
+
 # ── Key prefix constants ──────────────────────────────────────────────────────
 
 _PREFIX_ROOT: Final = "$."       # $.key → pyproject root key
@@ -51,9 +67,109 @@ _PREFIX_LOCAL: Final = "."       # .key → relative to in_key context
 _ROOT_ONLY: Final = "$"          # bare "$" → empty string
 _MARKER_FILE_LOCAL: Final = "^"  # ^key → strip this marker (file-local reference)
 
+# ── Error types ───────────────────────────────────────────────────────────────
 
-class ExpressionError(Exception):
-    """Raised when a Tyranno template expression cannot be evaluated."""
+
+@dataclass(frozen=True, slots=True)
+class ErrorLocation:
+    path: Path
+    line: int
+    column: int = 0
+
+
+class SyncError(Exception):
+    def __init__(self, *, location: ErrorLocation | None = None) -> None:
+        super().__init__()
+        self.location: ErrorLocation | None = location
+
+    def _loc_str(self) -> str:
+        if self.location:
+            return f" at {self.location.path}:{self.location.line}"
+        return ""
+
+    def __str__(self) -> str:
+        return f"Sync error{self._loc_str()}"
+
+
+class CommentSyntaxError(SyncError):
+    def __init__(self, *, detail: str, location: ErrorLocation | None = None) -> None:
+        super().__init__(location=location)
+        self.detail = detail
+
+    def __str__(self) -> str:
+        return f"Comment syntax error{self._loc_str()}: {self.detail}"
+
+
+class ExpressionError(SyncError):
+    def __init__(self, *, context: str | None = None, location: ErrorLocation | None = None) -> None:
+        super().__init__(location=location)
+        self.context = context
+
+    def __str__(self) -> str:
+        ctx = f" (in {self.context!r})" if self.context else ""
+        return f"Expression error{self._loc_str()}{ctx}"
+
+
+class NoSuchKeyError(ExpressionError):
+    def __init__(self, key: str, *, context: str | None = None, location: ErrorLocation | None = None) -> None:
+        super().__init__(context=context, location=location)
+        self.key = key
+
+    def __str__(self) -> str:
+        ctx = f" (in {self.context!r})" if self.context else ""
+        return f"Key not found{self._loc_str()}: {self.key!r}{ctx}"
+
+
+class NoSuchFunctionError(ExpressionError):
+    def __init__(self, name: str, *, context: str | None = None, location: ErrorLocation | None = None) -> None:
+        super().__init__(context=context, location=location)
+        self.name = name
+
+    def __str__(self) -> str:
+        ctx = f" (in {self.context!r})" if self.context else ""
+        return f"Unknown function{self._loc_str()}: {self.name!r}{ctx}"
+
+
+class SignatureMismatchError(ExpressionError):
+    def __init__(
+        self,
+        name: str,
+        *,
+        expected: str,
+        actual: str,
+        context: str | None = None,
+        location: ErrorLocation | None = None,
+    ) -> None:
+        super().__init__(context=context, location=location)
+        self.name = name
+        self.expected = expected
+        self.actual = actual
+
+    def __str__(self) -> str:
+        return (
+            f"Signature mismatch for {self.name!r}{self._loc_str()}: "
+            f"expected {self.expected}, got {self.actual}"
+        )
+
+
+class FunctionFailedError(ExpressionError):
+    def __init__(
+        self,
+        name: str,
+        *,
+        cause: str,
+        context: str | None = None,
+        location: ErrorLocation | None = None,
+    ) -> None:
+        super().__init__(context=context, location=location)
+        self.name = name
+        self.cause = cause
+
+    def __str__(self) -> str:
+        return f"Function {self.name!r} failed{self._loc_str()}: {self.cause}"
+
+
+# ── Data and Context ──────────────────────────────────────────────────────────
 
 
 @dataclass(frozen=True, slots=True)
@@ -84,7 +200,7 @@ class Data:
         Handles:
         - Simple key paths: `project.name`, `.vendor`
         - Pipe syntax: `project.keywords | yaml(@)`
-        - Chained functions: `project.description | yaml(@)`
+        - Chained functions: `project.version.pep440(@).minor_version`
         - Standalone calls: `now_utc().year`
         """
         expression = expression.strip()
@@ -111,7 +227,7 @@ class Data:
 
     def _parse_chained(self, expr: str) -> tuple[str, list[str]]:
         """Split `key.func1(args).func2(args)` into a key path and function list."""
-        if re.search(r"\s", expr):
+        if _WS_CHECK_RE.search(expr):
             expr = _WS_DOT_RE.sub(".", _MULTI_SPACE_RE.sub(" ", expr)).strip()
 
         segments = expr.split(".")
@@ -150,7 +266,7 @@ class Data:
             try:
                 return self.tree.access(simple_key)
             except (KeyError, TypeError) as e:
-                raise ExpressionError(f"Key not found: {simple_key!r}") from e
+                raise NoSuchKeyError(simple_key) from e
 
         jpath = expr if expr.startswith("$") else f"$.{simple_key}"
         try:
@@ -158,11 +274,11 @@ class Data:
             if matches:
                 return matches[0].value
         except Exception as e:
-            raise ExpressionError(f"Key not found: {expr!r}") from e
-        raise ExpressionError(f"Key not found: {expr!r}")
+            raise NoSuchKeyError(expr) from e
+        raise NoSuchKeyError(expr)
 
     def _apply_func(self, func_call: str, value: Any) -> Any:
-        """Apply a single function call like `yaml(@)` or attribute access like `year`."""
+        """Apply a single function call like `yaml(@)` or key access like `year`."""
         func_call = func_call.strip()
         if m := _FUNC_CALL_RE.fullmatch(func_call):
             name = m.group(1)
@@ -173,15 +289,17 @@ class Data:
                 return SOURCE_FUNCS[name](*extra_args)
             if name in FUNCS:
                 return FUNCS[name](value, *extra_args)
-            raise ExpressionError(f"Unknown function: {name!r}")
-        # No parentheses: treat as attribute access on the current value
+            raise NoSuchFunctionError(name)
+        # No parentheses: treat as attribute or dict-key access on the current value
         try:
             return getattr(value, func_call)
         except AttributeError:
-            raise ExpressionError(f"No attribute {func_call!r} on {type(value).__name__}")
+            if isinstance(value, dict) and func_call in value:
+                return value[func_call]
+            raise NoSuchFunctionError(func_call)
 
     @staticmethod
-    def _to_str(value: Any) -> str:
+    def _to_str(value: object) -> str:
         if isinstance(value, list):
             return ", ".join(str(v) for v in value)
         return str(value)

--- a/src/tyranno_sandbox/dot_tree.py
+++ b/src/tyranno_sandbox/dot_tree.py
@@ -208,13 +208,16 @@ class DotDictChecker:
             for v in node:
                 if isinstance(v, list | dict):
                     self.check_values(v)
+                else:
+                    self.check_primitive(v)
         elif isinstance(node, dict):
-            if bad := {k: type(v) for k, v in node.items() if not self.check_primitive(v)}:
+            if bad := {k: type(v) for k, v in node.items()
+                       if not isinstance(v, dict | list) and not self.is_primitive(v)}:
                 # noinspection PyUnboundLocalVariable
-                msg = f"Key(s) {bad.keys()} have invalid values of type(s) {set(bad.values())}"
+                msg = f"Key(s) {list(bad.keys())} have invalid values of type(s) {set(bad.values())}"
                 raise TypeError(msg)
             for v in node.values():
-                if isinstance(v, dict):
+                if isinstance(v, dict | list):
                     self.check_values(v)
         return node
 

--- a/src/tyranno_sandbox/functions/pep440.py
+++ b/src/tyranno_sandbox/functions/pep440.py
@@ -41,7 +41,11 @@ class Pep440SpecDict(TypedDict):
 
 @dataclass(frozen=True, slots=True)
 class Pep440Functions:
-    PEP440_PRE_STRS: ClassVar = {"alpha": "a", "beta": "b", "c": "rc", "pre": "rc", "preview": "rc"}
+    PEP440_PRE_STRS: ClassVar = {
+        "a": "a", "alpha": "a",
+        "b": "b", "beta": "b",
+        "rc": "rc", "c": "rc", "pre": "rc", "preview": "rc",
+    }
     PEP440_SPEC_RE: ClassVar = re.compile(r"""([A-Za-z0-9_-]++)(.++)""")
 
     def of(self, v: Pep440 | str) -> Pep440Dict:
@@ -76,7 +80,7 @@ class Pep440Functions:
         has_pre = v.pre is not None
         has_post = v.post is not None
         has_dev = v.dev is not None
-        if sum((has_pre, has_post, has_dev)):
+        if sum((has_pre, has_post, has_dev)) > 1:
             msg = f"PyPa package version {v} mixes pre, post, and/or dev numbers."
             raise FunctionError.from_call(msg, depth=2)
         epoch = f"{v.epoch}!" if v.epoch else ""

--- a/src/tyranno_sandbox/sync.py
+++ b/src/tyranno_sandbox/sync.py
@@ -7,14 +7,13 @@
 import re
 import shutil
 from dataclasses import dataclass, field
-from functools import cache, cached_property
+from functools import cache
 from re import Pattern
 from typing import TYPE_CHECKING, Final, Literal, NamedTuple, NewType, Self
 
 from loguru import logger
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
     from pathlib import Path
 
     from tyranno_sandbox.context import Context
@@ -38,50 +37,39 @@ class Tokens:
 
     @cache  # noqa: B019
     def inline_regex(self, comment_start: str, comment_end: str) -> Pattern[str]:
-        capture = self._fast_lazy_pattern(comment_end)
-        start_seq = re.escape(comment_start) + r"\s*" + re.escape(self.tyranno_inline)
-        # To allow possessive matching, we'll remove trailing whitespace after capture.
-        # So we don't need `\s*` here.
-        # But we do want to allow text after a comment end sequence.
-        # For example, this is ok: `<!-- ::tyranno:: ... --><!-- see above ... -->`.
-        end_seq = f"{re.escape(comment_end)}.*" if comment_end else ""
-        return re.compile(rf"^{start_seq}(?P<line>{capture}){end_seq}$")
+        """Build a regex matching a single `::tyranno::` comment line.
 
-    def _fast_lazy_pattern(self, end_token: str, *, lazy: bool = False) -> str:
-        end_tokens: list[str] = [re.escape(t) for t in end_token]
-        match len(end_tokens):
-            case 0:
-                # language=regexp
-                pattern = ".*+"
-            case 1 if lazy:
-                # language=regexp
-                pattern = r"[^⸨T0⸩]+"
-            case 1:
-                # language=regexp
-                pattern = r"[^⸨T0⸩]++"
-            case _ if lazy:
-                # language=regexp
-                pattern = r"(?:[^⸨T*⸩]++|[⸨T*⸩]+)*"
-            case _:
-                # language=regexp
-                pattern = r"(?:[^⸨T0⸩]++|⸨T0⸩(?!⸨T≽1⸩))*"
-        re.compile(r"⸨T(\d++)⸩").sub(lambda m: end_tokens[int(m.group(1))], pattern)
-        re.compile(r"⸨T≽(\d++)⸩").sub(lambda m: "".join(end_tokens[int(m.group(1)) :]), pattern)
-        re.compile(r"⸨T\*⸩").sub("".join(set(end_tokens)), pattern)
-        return pattern
+        The named group ``line`` captures everything between the marker and the
+        (optional) comment-close token, so that the caller can extract and
+        evaluate the template expression.
+        """
+        # Allow any leading whitespace (for indented comment lines).
+        start_seq = (
+            r"\s*"
+            + re.escape(comment_start)
+            + r"\s*"
+            + re.escape(self.tyranno_inline)
+        )
+        # Everything up to (but not including) the comment-close token.
+        if comment_end:
+            capture = r".*?"
+            end_seq = re.escape(comment_end) + r".*"
+        else:
+            capture = r".*"
+            end_seq = ""
+        return re.compile(rf"^{start_seq}(?P<line>{capture}){end_seq}$")
 
 
 TOKENS: Final = Tokens.create()
-
 
 Suffix = NewType("Suffix", str)
 
 
 class CommentTokenPair(NamedTuple):
-    """Start and optional end comment tokens (e.g. `("//", "")`).
+    """Start and optional end comment tokens (e.g. ``("//", "")``).
 
-    - If `end == ""`, the comment is single-line.
-    - If `end != ""`, the comment is multi-line.
+    - If ``end == ""``, the comment is single-line.
+    - If ``end != ""``, the comment is multi-line.
     """
 
     start: str
@@ -141,23 +129,19 @@ class DeltaBlock:
     def __getitem__(self, index: int) -> DeltaLine:
         return DeltaLine(self.templates[index], self.old_lines[index], self.new_lines[index])
 
-    @cached_property
+    @property
     def last_line_number(self) -> int:
         return self.first_line_number + len(self)
 
-    @cached_property
+    @property
     def n_lines_differ(self) -> int:
-        return sum(i == j for i, j in zip(self.old_lines, self.new_lines, strict=False))
+        return sum(o != n for o, n in zip(self.old_lines, self.new_lines, strict=False))
 
     def __str__(self) -> str:
         if self.kind == "block":
-            return repr(self)  # TODO
-        l0, ln, ob, nb = (
-            self.first_line_number,
-            self.last_line_number,
-            self.old_lines,
-            self.new_lines,
-        )
+            return repr(self)
+        l0, ln = self.first_line_number, self.last_line_number
+        ob, nb = self.old_lines, self.new_lines
         if len(nb) == 1 and nb == ob:
             return f"Line {l0} unchanged."
         if len(nb) == 1:
@@ -169,18 +153,21 @@ class DeltaBlock:
 
 @dataclass(slots=True)
 class SyncHelper:
-    """Utility that substitutes `::tyranno::` comments in a file."""
+    """Substitutes `::tyranno::` template comments in a single file.
+
+    After calling [run][], inspect [new_lines][] for the output content and
+    [hits][] for a summary of what changed.
+    """
 
     context: Context
     path: Path
-    # Filled in by `__post_init__`:
     _pattern: Pattern[str] = field(init=False)
-    _line_number: int = field(default=0, init=False)  # Start at line #0 (let str messages add + 1).
-    _old_lines: list[str | None] = field(default_factory=list, init=False)  # don't modify
-    _new_lines: list[str | None] = field(default_factory=list, init=False)
-    _templates: list[str | None] = field(default_factory=list, init=False)
-    _template_rewind: int = field(default=-1, init=False)
+    _new_lines: list[str] = field(default_factory=list, init=False)
     _hits: list[DeltaBlock] = field(default_factory=list, init=False)
+
+    def __post_init__(self) -> None:
+        tokens = _COMMENTS[Suffix(self.path.suffix or self.path.name)]
+        self._pattern = TOKENS.inline_regex(tokens.start, tokens.end)
 
     @property
     def new_lines(self) -> list[str]:
@@ -190,41 +177,46 @@ class SyncHelper:
     def hits(self) -> list[DeltaBlock]:
         return self._hits
 
-    def __post_init__(self) -> None:
-        start, end = _COMMENTS[Suffix(self.path.suffix or self.path.name)]
-        self._pattern = TOKENS.inline_regex(start, end)
-        self._old_lines = [*self.path.read_text().splitlines(), ""]
-
     def run(self) -> None:
-        for _ in range(len(self._old_lines)):
-            if hit := self._next_line():
-                self._hits.append(hit)
-            self._line_number += 1
+        """Process the file line-by-line, expanding `::tyranno::` expressions."""
+        lines = self.path.read_text(encoding="utf-8").splitlines()
+        result: list[str] = []
+        i = 0
+        while i < len(lines):
+            m = self._pattern.fullmatch(lines[i].rstrip())
+            if not m:
+                result.append(lines[i])
+                i += 1
+                continue
 
-    def _next_line(self) -> DeltaBlock | None:
-        line = self._old_lines[self._line_number]
-        if self._template_rewind > 0:  # Skip this line, which will be replaced (eat at the buffer)
-            self._template_rewind -= 1
-        elif self._template_rewind:  # We finished the skipped lines (ate the whole buffer)
-            original = self._old_lines[self._line_number - len(self._templates) : self._line_number]
-            new = list(self._generate_lines(self._templates))
-            self._new_lines += new
-            buffer = list(self._templates)
-            self._templates = []
-            self._template_rewind = -1
-            return DeltaBlock("inline", self.path, self._line_number, buffer, original, new)
-        elif m := self._pattern.fullmatch(line):  # We're in a block: start or add to a buffer
-            self._templates.append(m.group("capture"))
-        elif self._templates:  # It's the first real line after a block
-            self._template_rewind = len(self._templates)  # Begin eating the buffer
-            self._templates.append(line)  # Include the first real line, too (it'll be used as-is)
-        else:
-            self._new_lines.append(line)
-        return None
+            # Collect consecutive ::tyranno:: comment lines.
+            first_line = i
+            header_lines: list[str] = [lines[i]]
+            expressions: list[str] = [m.group("line").strip()]
+            i += 1
+            while i < len(lines):
+                m2 = self._pattern.fullmatch(lines[i].rstrip())
+                if not m2:
+                    break
+                header_lines.append(lines[i])
+                expressions.append(m2.group("line").strip())
+                i += 1
 
-    def _generate_lines(self, templates: list[str]) -> Generator[str]:
-        for template in templates:
-            yield self.context.data.replace_vars_in(template)
+            # Keep the ::tyranno:: comment lines verbatim.
+            result.extend(header_lines)
+
+            # Consume old content lines (one per template) and emit new ones.
+            n = len(expressions)
+            old_lines = lines[i : i + n]
+            i += n
+            new_lines = [self.context.data.replace_vars_in(e) for e in expressions]
+            result.extend(new_lines)
+
+            self._hits.append(
+                DeltaBlock("inline", self.path, first_line, expressions, old_lines, new_lines)
+            )
+
+        self._new_lines = result
 
 
 @dataclass(frozen=True, slots=True)
@@ -236,37 +228,43 @@ class Syncer:
 
     def run(self) -> None:
         for path in self.context.find_targets():
+            suffix = Suffix(path.suffix or path.name)
+            if suffix not in _COMMENTS:
+                logger.debug(f"Skipping {path}: no comment tokens defined for suffix '{suffix}'")
+                continue
             self.run_on(path)
 
     def run_on(self, path: Path) -> None:
         helper = SyncHelper(self.context, path)
         helper.run()
-        self._save(path, helper.new_lines)
+        if not self.context.dry_run:
+            self._save(path, helper.new_lines)
         self._log(path, helper.hits)
 
     def _save(self, path: Path, lines: list[str]) -> None:
         if self.backup:
             bak_path = self.context.bak_path(path)
+            bak_path.parent.mkdir(parents=True, exist_ok=True)
             shutil.copyfile(path, bak_path)
         self._write(path, lines)
 
     def _log(self, path: Path, hits: list[DeltaBlock]) -> None:
         for hit in hits:
-            logger.debug(hit)
-        bak_path = self.context.bak_path(path) if self.backup else None
+            logger.debug(str(hit))
+        bak_msg = f" (backup: {self.context.bak_path(path)})" if self.backup else ""
+        n_differ = sum(hit.n_lines_differ for hit in hits)
+        n_total = sum(len(hit) for hit in hits)
+        n_blocks = len(hits)
         logger.info(
-            "Updated %s: %i lines changed (of %i in %i blocks)%s"
-            + (f" (backup saved as {bak_path})" if bak_path else " (no backup created)"),
-            path,
-            sum(hit.n_lines_differ for hit in hits),
-            sum(len(hit) for hit in hits),
-            len(hits),
+            f"Processed {path}: {n_differ} lines changed"
+            f" (of {n_total} in {n_blocks} blocks){bak_msg}"
         )
 
     def _write(self, path: Path, lines: list[str]) -> None:
+        content = "\n".join(lines) + "\n"
         temp_file = path.with_name(f".~{path.name}.temp")
         try:
-            temp_file.write_text("\n".join(lines), encoding="utf-8")
-            shutil.move(temp_file, path)
+            temp_file.write_text(content, encoding="utf-8")
+            shutil.move(str(temp_file), str(path))
         finally:
             temp_file.unlink(missing_ok=True)

--- a/src/tyranno_sandbox/sync.py
+++ b/src/tyranno_sandbox/sync.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING, Final, Literal, NamedTuple, NewType, Self
 
 from loguru import logger
 
+from tyranno_sandbox.context import ExpressionError
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -39,7 +41,7 @@ class Tokens:
     def inline_regex(self, comment_start: str, comment_end: str) -> Pattern[str]:
         """Build a regex matching a single `::tyranno::` comment line.
 
-        The named group ``line`` captures everything between the marker and the
+        The named group `line` captures everything between the marker and the
         (optional) comment-close token, so that the caller can extract and
         evaluate the template expression.
         """
@@ -209,7 +211,14 @@ class SyncHelper:
             n = len(expressions)
             old_lines = lines[i : i + n]
             i += n
-            new_lines = [self.context.data.replace_vars_in(e) for e in expressions]
+            new_lines: list[str] = []
+            content_start = first_line + len(header_lines) + 1  # 1-based line number
+            for idx, expr in enumerate(expressions):
+                try:
+                    new_lines.append(self.context.data.replace_vars_in(expr))
+                except ExpressionError as e:
+                    logger.error(f"{self.path}:{content_start + idx}: {e}")
+                    new_lines.append(old_lines[idx] if idx < len(old_lines) else "")
             result.extend(new_lines)
 
             self._hits.append(

--- a/src/tyranno_sandbox/sync.py
+++ b/src/tyranno_sandbox/sync.py
@@ -70,8 +70,8 @@ Suffix = NewType("Suffix", str)
 class CommentTokenPair(NamedTuple):
     """Start and optional end comment tokens (e.g. ``("//", "")``).
 
-    - If ``end == ""``, the comment is single-line.
-    - If ``end != ""``, the comment is multi-line.
+    - If `end == ""`, the comment is single-line.
+    - If `end != ""`, the comment is multi-line.
     """
 
     start: str

--- a/src/tyranno_sandbox/tyranno_functions.py
+++ b/src/tyranno_sandbox/tyranno_functions.py
@@ -8,20 +8,45 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
+from datetime import datetime
 from typing import Any, Final
 
-import yaml
-from packaging.version import Version
+import yaml as _yaml_lib
 
 from tyranno_sandbox._global_vars import STARTUP
+from tyranno_sandbox.functions.pep440 import Pep440Dict, Pep440Functions
+from tyranno_sandbox.functions.semver import SemverDict, SemverFunctions
+from tyranno_sandbox.functions.times import DatetimeFunctions, TimeDict
 
-__all__ = ["FUNCS", "SOURCE_FUNCS"]
+__all__ = [
+    "FUNCS",
+    "SOURCE_FUNCS",
+    "from_json",
+    "from_yaml",
+    "join",
+    "lower",
+    "now_local",
+    "now_utc",
+    "pep440",
+    "pep440_minor",
+    "replace",
+    "semver",
+    "sort",
+    "timestamp",
+    "upper",
+    "yaml",
+    "yaml_multiline",
+]
 
 # Maps name → callable(value: Any, *extra_args: str) → Any
 FUNCS: Final[dict[str, Callable[..., Any]]] = {}
 
 # Maps name → callable(*extra_args: str) → Any  (produces a value; ignores pipeline input)
 SOURCE_FUNCS: Final[dict[str, Callable[..., Any]]] = {}
+
+_f_time: Final = DatetimeFunctions()
+_f_pep440: Final = Pep440Functions()
+_f_semver: Final = SemverFunctions()
 
 
 def _func(name: str) -> Callable[[Callable], Callable]:
@@ -41,8 +66,7 @@ def _source(name: str) -> Callable[[Callable], Callable]:
 
 
 def _yaml_dump(value: Any) -> str:
-    """Serialize *value* with PyYAML, stripping document-end markers."""
-    raw = yaml.dump(value, allow_unicode=True, default_flow_style=False)
+    raw = _yaml_lib.dump(value, allow_unicode=True, default_flow_style=False)
     return raw.strip().removesuffix("...").strip()
 
 
@@ -50,73 +74,82 @@ def _yaml_dump(value: Any) -> str:
 
 
 @_source("now_utc")
-def _now_utc() -> object:
-    return STARTUP.utc
+def now_utc() -> TimeDict:
+    return _f_time.of(STARTUP.utc)
 
 
 @_source("now_local")
-def _now_local() -> object:
-    return STARTUP.local
+def now_local() -> TimeDict:
+    return _f_time.of(STARTUP.local)
 
 
 # ── Transform functions ───────────────────────────────────────────────────────
 
 
 @_func("yaml")
-def _yaml_func(value: Any) -> str:
+def yaml(value: Any) -> str:
     return _yaml_dump(value)
 
 
 @_func("from_yaml")
-def _from_yaml(value: Any) -> Any:
-    return yaml.safe_load(str(value))
+def from_yaml(value: Any) -> Any:
+    return _yaml_lib.safe_load(str(value))
 
 
 @_func("from_json")
-def _from_json(value: Any) -> Any:
+def from_json(value: Any) -> Any:
     return json.loads(str(value))
 
 
 @_func("yaml_multiline")
-def _yaml_multiline(value: Any, indent: str = "0") -> str:
+def yaml_multiline(value: Any, indent: int = 0) -> str:
     pad = " " * int(indent)
-    items = [v.strip() for v in str(value).split(",") if v.strip()]
+    items = value if isinstance(value, list) else [v.strip() for v in str(value).split(",") if v.strip()]
     return "\n".join(f"{pad}{_yaml_dump(item)}" for item in items)
 
 
 @_func("lower")
-def _lower(value: Any) -> str:
+def lower(value: Any) -> str:
     return str(value).lower()
 
 
 @_func("upper")
-def _upper(value: Any) -> str:
+def upper(value: Any) -> str:
     return str(value).upper()
 
 
 @_func("replace")
-def _replace(value: Any, old: str, new: str) -> str:
+def replace(value: Any, old: str, new: str) -> str:
     return str(value).replace(old, new)
 
 
-@_func("spdx_license")
-def _spdx_license(value: Any) -> str:
-    return str(value)
+@_func("pep440")
+def pep440(value: Any) -> Pep440Dict:
+    return _f_pep440.of(str(value))
 
 
 @_func("pep440_minor")
-def _pep440_minor(value: Any) -> str:
-    v = Version(str(value))
-    return f"{v.major}.{v.minor}"
+def pep440_minor(value: Any) -> str:
+    return _f_pep440.of(str(value))["minor_version"]
+
+
+@_func("semver")
+def semver(value: Any) -> SemverDict:
+    return _f_semver.of(str(value))
+
+
+@_func("timestamp")
+def timestamp(value: Any) -> TimeDict:
+    return _f_time.of(datetime.fromisoformat(str(value)))
 
 
 @_func("sort")
-def _sort(value: Any) -> str:
-    items = [i.strip() for i in str(value).split(",")]
-    return ", ".join(sorted(items))
+def sort(value: Any) -> str:
+    items = value if isinstance(value, list) else [i.strip() for i in str(value).split(",") if i.strip()]
+    return ", ".join(str(v) for v in sorted(items, key=str))
 
 
 @_func("join")
-def _join(value: Any, sep: str = ", ") -> str:
-    items = [i.strip() for i in str(value).split(",")]
-    return sep.join(items)
+def join(value: Any, sep: str = ", ") -> str:
+    items = value if isinstance(value, list) else [i.strip() for i in str(value).split(",")]
+    return sep.join(str(i) for i in items)

--- a/src/tyranno_sandbox/tyranno_functions.py
+++ b/src/tyranno_sandbox/tyranno_functions.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Copyright 2020-2026, Contributors to Tyrannosaurus
+# SPDX-PackageHomePage: https://github.com/dmyersturnbull/tyrannosaurus
+# SPDX-License-Identifier: Apache-2.0
+
+"""Centralized registry of Tyranno template expression functions."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any, Final
+
+import yaml
+from packaging.version import Version
+
+from tyranno_sandbox._global_vars import STARTUP
+
+__all__ = ["FUNCS", "SOURCE_FUNCS"]
+
+# Maps name → callable(value: Any, *extra_args: str) → Any
+FUNCS: Final[dict[str, Callable[..., Any]]] = {}
+
+# Maps name → callable(*extra_args: str) → Any  (produces a value; ignores pipeline input)
+SOURCE_FUNCS: Final[dict[str, Callable[..., Any]]] = {}
+
+
+def _func(name: str) -> Callable[[Callable], Callable]:
+    def decorator(fn: Callable) -> Callable:
+        FUNCS[name] = fn
+        return fn
+
+    return decorator
+
+
+def _source(name: str) -> Callable[[Callable], Callable]:
+    def decorator(fn: Callable) -> Callable:
+        SOURCE_FUNCS[name] = fn
+        return fn
+
+    return decorator
+
+
+def _yaml_dump(value: Any) -> str:
+    """Serialize *value* with PyYAML, stripping document-end markers."""
+    raw = yaml.dump(value, allow_unicode=True, default_flow_style=False)
+    return raw.strip().removesuffix("...").strip()
+
+
+# ── Source functions ──────────────────────────────────────────────────────────
+
+
+@_source("now_utc")
+def _now_utc() -> object:
+    return STARTUP.utc
+
+
+@_source("now_local")
+def _now_local() -> object:
+    return STARTUP.local
+
+
+# ── Transform functions ───────────────────────────────────────────────────────
+
+
+@_func("yaml")
+def _yaml_func(value: Any) -> str:
+    return _yaml_dump(value)
+
+
+@_func("from_yaml")
+def _from_yaml(value: Any) -> Any:
+    return yaml.safe_load(str(value))
+
+
+@_func("from_json")
+def _from_json(value: Any) -> Any:
+    return json.loads(str(value))
+
+
+@_func("yaml_multiline")
+def _yaml_multiline(value: Any, indent: str = "0") -> str:
+    pad = " " * int(indent)
+    items = [v.strip() for v in str(value).split(",") if v.strip()]
+    return "\n".join(f"{pad}{_yaml_dump(item)}" for item in items)
+
+
+@_func("lower")
+def _lower(value: Any) -> str:
+    return str(value).lower()
+
+
+@_func("upper")
+def _upper(value: Any) -> str:
+    return str(value).upper()
+
+
+@_func("replace")
+def _replace(value: Any, old: str, new: str) -> str:
+    return str(value).replace(old, new)
+
+
+@_func("spdx_license")
+def _spdx_license(value: Any) -> str:
+    return str(value)
+
+
+@_func("pep440_minor")
+def _pep440_minor(value: Any) -> str:
+    v = Version(str(value))
+    return f"{v.major}.{v.minor}"
+
+
+@_func("sort")
+def _sort(value: Any) -> str:
+    items = [i.strip() for i in str(value).split(",")]
+    return ", ".join(sorted(items))
+
+
+@_func("join")
+def _join(value: Any, sep: str = ", ") -> str:
+    items = [i.strip() for i in str(value).split(",")]
+    return sep.join(items)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,7 @@
 """Utilities for tests."""
 
 import logging
+import os
 import time
 from contextlib import ExitStack, contextmanager, redirect_stderr, redirect_stdout
 from dataclasses import dataclass, field

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: Copyright 2020-2026, Contributors to Tyrannosaurus
+# SPDX-PackageHomePage: https://github.com/dmyersturnbull/tyrannosaurus
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit and integration tests for context.py expression evaluation."""
+
+import pytest
+
+from tyranno_sandbox.context import Data, ExpressionError
+from tyranno_sandbox.dot_tree import DotTree
+
+
+def _make_data(raw: dict) -> Data:
+    return Data(DotTree.from_nested(raw))
+
+
+@pytest.fixture()
+def data() -> Data:
+    return _make_data({
+        "project": {
+            "name": "my-project",
+            "description": "A test project",
+            "version": "1.2.3",
+            "keywords": ["alpha", "beta", "gamma"],
+            "urls": {"Homepage": "https://example.com/my-project"},
+        },
+        "tool": {
+            "tyranno": {
+                "data": {
+                    "vendor": "acme",
+                    "namespace": "my_project",
+                },
+            },
+        },
+    })
+
+
+class TestReplaceVarsIn:
+    def test_no_expressions(self, data: Data) -> None:
+        assert data.replace_vars_in("no vars here") == "no vars here"
+
+    def test_single_expression(self, data: Data) -> None:
+        assert data.replace_vars_in("$<<project.name>>") == "my-project"
+
+    def test_multiple_expressions(self, data: Data) -> None:
+        result = data.replace_vars_in("$<<project.name>> v$<<project.version>>")
+        assert result == "my-project v1.2.3"
+
+    def test_expression_surrounded_by_text(self, data: Data) -> None:
+        result = data.replace_vars_in("name = $<<project.name>> end")
+        assert result == "name = my-project end"
+
+    def test_list_value_comma_separated(self, data: Data) -> None:
+        result = data.replace_vars_in("$<<project.keywords>>")
+        assert result == "alpha, beta, gamma"
+
+
+class TestExpandVarSimpleKeys:
+    def test_dotted_key(self, data: Data) -> None:
+        assert data.expand_var("project.name") == "my-project"
+
+    def test_nested_key(self, data: Data) -> None:
+        assert data.expand_var("project.urls.Homepage") == "https://example.com/my-project"
+
+    def test_dollar_prefix(self, data: Data) -> None:
+        assert data.expand_var("$.project.name") == "my-project"
+
+    def test_at_prefix(self, data: Data) -> None:
+        assert data.expand_var("@.vendor") == "acme"
+
+    def test_dot_prefix_resolves_to_tyranno_data(self, data: Data) -> None:
+        assert data.expand_var(".vendor") == "acme"
+
+    def test_empty_expression(self, data: Data) -> None:
+        assert data.expand_var("") == ""
+
+    def test_bare_dollar_returns_empty(self, data: Data) -> None:
+        assert data.expand_var("$") == ""
+
+
+class TestExpandVarPipeSyntax:
+    def test_pipe_to_lower(self, data: Data) -> None:
+        assert data.expand_var("project.name | lower(@)") == "my-project"
+
+    def test_pipe_to_upper(self, data: Data) -> None:
+        assert data.expand_var("project.name | upper(@)") == "MY-PROJECT"
+
+    def test_pipe_to_yaml(self, data: Data) -> None:
+        result = data.expand_var("project.urls.Homepage | yaml(@)")
+        assert "example.com" in result
+
+    def test_pipe_list_to_yaml(self, data: Data) -> None:
+        result = data.expand_var("project.keywords | yaml(@)")
+        assert "- alpha" in result
+
+    def test_chained_pipes(self, data: Data) -> None:
+        result = data.expand_var("project.name | upper(@) | lower(@)")
+        assert result == "my-project"
+
+    def test_pipe_replace(self, data: Data) -> None:
+        result = data.expand_var("project.name | replace(@, '-', '_')")
+        assert result == "my_project"
+
+
+class TestExpandVarPep440:
+    def test_pep440_minor(self, data: Data) -> None:
+        assert data.expand_var("project.version | pep440_minor(@)") == "1.2"
+
+
+class TestExpandVarNowUtc:
+    def test_now_utc_year(self, data: Data) -> None:
+        result = data.expand_var("now_utc().year")
+        assert result.isdigit()
+        assert 2020 <= int(result) <= 2100
+
+    def test_now_utc_month(self, data: Data) -> None:
+        result = data.expand_var("now_utc().month")
+        assert result.isdigit()
+        assert 1 <= int(result) <= 12
+
+    def test_now_local_year(self, data: Data) -> None:
+        result = data.expand_var("now_local().year")
+        assert result.isdigit()
+
+
+class TestExpandVarErrors:
+    def test_missing_key_raises(self, data: Data) -> None:
+        with pytest.raises(ExpressionError, match="not found"):
+            data.expand_var("project.nonexistent")
+
+    def test_unknown_function_raises(self, data: Data) -> None:
+        with pytest.raises(ExpressionError, match="Unknown function"):
+            data.expand_var("project.name | no_such_func(@)")
+
+    def test_bad_attribute_raises(self, data: Data) -> None:
+        with pytest.raises(ExpressionError):
+            data.expand_var("now_utc().no_such_attr")
+
+
+class TestIntegration:
+    def test_replace_vars_in_full_template(self, data: Data) -> None:
+        template = 'name = "$<<project.name>>" version = "$<<project.version>>"'
+        result = data.replace_vars_in(template)
+        assert result == 'name = "my-project" version = "1.2.3"'
+
+    def test_dot_prefix_in_tyranno_data(self, data: Data) -> None:
+        result = data.replace_vars_in("$<<.vendor>>")
+        assert result == "acme"
+
+    def test_at_prefix_in_tyranno_data(self, data: Data) -> None:
+        result = data.replace_vars_in("$<<@.vendor>>")
+        assert result == "acme"
+
+
+class TestSyncHelperIntegration:
+    def test_inline_replacement(self, tmp_path, data: Data) -> None:
+        from tyranno_sandbox.context import Context
+        from tyranno_sandbox.sync import SyncHelper
+        from tyranno_sandbox._global_vars import EnvGlobalVarsFactory
+        import os
+
+        env = EnvGlobalVarsFactory(env=os.environ)()
+        ctx = Context(env=env, repo_dir=tmp_path, data=data, dry_run=True)
+
+        target = tmp_path / "test.toml"
+        target.write_text(
+            '# ::tyranno:: name = "$<<project.name>>"\n'
+            'name = "old-value"\n',
+            encoding="utf-8",
+        )
+
+        helper = SyncHelper(ctx, target)
+        helper.run()
+
+        assert helper.new_lines[0].startswith("# ::tyranno::")
+        assert helper.new_lines[1] == 'name = "my-project"'
+
+    def test_multiple_consecutive_tyranno_lines(self, tmp_path, data: Data) -> None:
+        from tyranno_sandbox.context import Context
+        from tyranno_sandbox.sync import SyncHelper
+        from tyranno_sandbox._global_vars import EnvGlobalVarsFactory
+        import os
+
+        env = EnvGlobalVarsFactory(env=os.environ)()
+        ctx = Context(env=env, repo_dir=tmp_path, data=data, dry_run=True)
+
+        target = tmp_path / "test.toml"
+        target.write_text(
+            '# ::tyranno:: $<<project.name>>\n'
+            '# ::tyranno:: $<<project.version>>\n'
+            'old-name\n'
+            'old-version\n',
+            encoding="utf-8",
+        )
+
+        helper = SyncHelper(ctx, target)
+        helper.run()
+
+        assert helper.new_lines[2] == "my-project"
+        assert helper.new_lines[3] == "1.2.3"
+
+    def test_non_tyranno_lines_unchanged(self, tmp_path, data: Data) -> None:
+        from tyranno_sandbox.context import Context
+        from tyranno_sandbox.sync import SyncHelper
+        from tyranno_sandbox._global_vars import EnvGlobalVarsFactory
+        import os
+
+        env = EnvGlobalVarsFactory(env=os.environ)()
+        ctx = Context(env=env, repo_dir=tmp_path, data=data, dry_run=True)
+
+        target = tmp_path / "test.toml"
+        content = "# regular comment\nsome_key = 'value'\n"
+        target.write_text(content, encoding="utf-8")
+
+        helper = SyncHelper(ctx, target)
+        helper.run()
+
+        assert helper.new_lines == ["# regular comment", "some_key = 'value'"]
+        assert helper.hits == []

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -4,10 +4,14 @@
 
 """Unit and integration tests for context.py expression evaluation."""
 
+from pathlib import Path
+
 import pytest
 
-from tyranno_sandbox.context import Data, ExpressionError
+from tyranno_sandbox._global_vars import GlobalVars
+from tyranno_sandbox.context import Context, Data, ExpressionError
 from tyranno_sandbox.dot_tree import DotTree
+from tyranno_sandbox.sync import SyncHelper
 
 
 def _make_data(raw: dict) -> Data:
@@ -33,6 +37,19 @@ def data() -> Data:
             },
         },
     })
+
+
+@pytest.fixture()
+def env(tmp_path: Path) -> GlobalVars:
+    return GlobalVars(
+        cache_dir=tmp_path / "cache",
+        config_dir=tmp_path / "config",
+        data_dir=tmp_path / "data",
+        log_dir=tmp_path / "log",
+        tyranno_dir=".tyranno",
+        log_format="",
+        debug_mode=False,
+    )
 
 
 class TestReplaceVarsIn:
@@ -73,9 +90,6 @@ class TestExpandVarSimpleKeys:
 
     def test_empty_expression(self, data: Data) -> None:
         assert data.expand_var("") == ""
-
-    def test_bare_dollar_returns_empty(self, data: Data) -> None:
-        assert data.expand_var("$") == ""
 
 
 class TestExpandVarPipeSyntax:
@@ -153,13 +167,7 @@ class TestIntegration:
 
 
 class TestSyncHelperIntegration:
-    def test_inline_replacement(self, tmp_path, data: Data) -> None:
-        from tyranno_sandbox.context import Context
-        from tyranno_sandbox.sync import SyncHelper
-        from tyranno_sandbox._global_vars import EnvGlobalVarsFactory
-        import os
-
-        env = EnvGlobalVarsFactory(env=os.environ)()
+    def test_inline_replacement(self, tmp_path: Path, data: Data, env: GlobalVars) -> None:
         ctx = Context(env=env, repo_dir=tmp_path, data=data, dry_run=True)
 
         target = tmp_path / "test.toml"
@@ -175,21 +183,15 @@ class TestSyncHelperIntegration:
         assert helper.new_lines[0].startswith("# ::tyranno::")
         assert helper.new_lines[1] == 'name = "my-project"'
 
-    def test_multiple_consecutive_tyranno_lines(self, tmp_path, data: Data) -> None:
-        from tyranno_sandbox.context import Context
-        from tyranno_sandbox.sync import SyncHelper
-        from tyranno_sandbox._global_vars import EnvGlobalVarsFactory
-        import os
-
-        env = EnvGlobalVarsFactory(env=os.environ)()
+    def test_multiple_consecutive_tyranno_lines(self, tmp_path: Path, data: Data, env: GlobalVars) -> None:
         ctx = Context(env=env, repo_dir=tmp_path, data=data, dry_run=True)
 
         target = tmp_path / "test.toml"
         target.write_text(
-            '# ::tyranno:: $<<project.name>>\n'
-            '# ::tyranno:: $<<project.version>>\n'
-            'old-name\n'
-            'old-version\n',
+            "# ::tyranno:: $<<project.name>>\n"
+            "# ::tyranno:: $<<project.version>>\n"
+            "old-name\n"
+            "old-version\n",
             encoding="utf-8",
         )
 
@@ -199,13 +201,7 @@ class TestSyncHelperIntegration:
         assert helper.new_lines[2] == "my-project"
         assert helper.new_lines[3] == "1.2.3"
 
-    def test_non_tyranno_lines_unchanged(self, tmp_path, data: Data) -> None:
-        from tyranno_sandbox.context import Context
-        from tyranno_sandbox.sync import SyncHelper
-        from tyranno_sandbox._global_vars import EnvGlobalVarsFactory
-        import os
-
-        env = EnvGlobalVarsFactory(env=os.environ)()
+    def test_non_tyranno_lines_unchanged(self, tmp_path: Path, data: Data, env: GlobalVars) -> None:
         ctx = Context(env=env, repo_dir=tmp_path, data=data, dry_run=True)
 
         target = tmp_path / "test.toml"

--- a/tests/test_tyranno_functions.py
+++ b/tests/test_tyranno_functions.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright 2020-2026, Contributors to Tyrannosaurus
+# SPDX-PackageHomePage: https://github.com/dmyersturnbull/tyrannosaurus
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the Tyranno function registry."""
+
+import pytest
+
+from tyranno_sandbox.tyranno_functions import FUNCS, SOURCE_FUNCS
+
+
+class TestYamlFunc:
+    def test_plain_string(self) -> None:
+        assert FUNCS["yaml"]("hello world") == "hello world"
+
+    def test_string_needing_quotes(self) -> None:
+        result = FUNCS["yaml"]("with: colon")
+        assert result == "'with: colon'"
+
+    def test_boolean_string_gets_quoted(self) -> None:
+        result = FUNCS["yaml"]("true")
+        assert result == "'true'"
+
+    def test_url_is_valid_yaml_scalar(self) -> None:
+        result = FUNCS["yaml"]("https://example.com")
+        assert "example.com" in result
+
+    def test_list_becomes_block_sequence(self) -> None:
+        result = FUNCS["yaml"](["alpha", "beta"])
+        assert "- alpha" in result
+        assert "- beta" in result
+
+    def test_integer(self) -> None:
+        result = FUNCS["yaml"](42)
+        assert result == "42"
+
+
+class TestFromYaml:
+    def test_parses_scalar(self) -> None:
+        assert FUNCS["from_yaml"]("hello") == "hello"
+
+    def test_parses_sequence(self) -> None:
+        result = FUNCS["from_yaml"]("- a\n- b")
+        assert result == ["a", "b"]
+
+    def test_roundtrip(self) -> None:
+        original = ["ci/cd", "python"]
+        dumped = FUNCS["yaml"](original)
+        parsed = FUNCS["from_yaml"](dumped)
+        assert parsed == original
+
+
+class TestFromJson:
+    def test_parses_object(self) -> None:
+        result = FUNCS["from_json"]('{"key": "value"}')
+        assert result == {"key": "value"}
+
+    def test_parses_array(self) -> None:
+        result = FUNCS["from_json"]('["a", "b"]')
+        assert result == ["a", "b"]
+
+
+class TestStringFuncs:
+    def test_lower(self) -> None:
+        assert FUNCS["lower"]("Hello World") == "hello world"
+
+    def test_upper(self) -> None:
+        assert FUNCS["upper"]("hello") == "HELLO"
+
+    def test_replace(self) -> None:
+        assert FUNCS["replace"]("foo_bar", "_", "-") == "foo-bar"
+
+    def test_sort(self) -> None:
+        assert FUNCS["sort"]("banana, apple, cherry") == "apple, banana, cherry"
+
+    def test_join_default_sep(self) -> None:
+        assert FUNCS["join"]("a, b, c") == "a, b, c"
+
+    def test_join_custom_sep(self) -> None:
+        assert FUNCS["join"]("a, b, c", " | ") == "a | b | c"
+
+    def test_spdx_license(self) -> None:
+        assert FUNCS["spdx_license"]("Apache-2.0") == "Apache-2.0"
+
+    def test_pep440_minor(self) -> None:
+        assert FUNCS["pep440_minor"]("1.2.3") == "1.2"
+
+    def test_pep440_minor_strips_patch(self) -> None:
+        assert FUNCS["pep440_minor"]("3.14.0") == "3.14"
+
+
+class TestSourceFuncs:
+    def test_now_utc_returns_datetime(self) -> None:
+        import datetime
+
+        result = SOURCE_FUNCS["now_utc"]()
+        assert isinstance(result, datetime.datetime)
+        assert result.tzinfo is not None
+
+    def test_now_local_returns_datetime(self) -> None:
+        import datetime
+
+        result = SOURCE_FUNCS["now_local"]()
+        assert isinstance(result, datetime.datetime)
+
+    def test_now_utc_is_startup_time(self) -> None:
+        from tyranno_sandbox._global_vars import STARTUP
+
+        result = SOURCE_FUNCS["now_utc"]()
+        assert result == STARTUP.utc
+
+    def test_now_utc_year_is_reasonable(self) -> None:
+        result = SOURCE_FUNCS["now_utc"]()
+        assert 2020 <= result.year <= 2100
+
+    def test_now_utc_and_now_local_differ_only_by_timezone(self) -> None:
+        utc = SOURCE_FUNCS["now_utc"]()
+        local = SOURCE_FUNCS["now_local"]()
+        import datetime
+
+        diff = abs((utc - local.astimezone(datetime.timezone.utc)).total_seconds())
+        assert diff < 1  # same instant
+
+
+class TestYamlMultiline:
+    def test_basic(self) -> None:
+        result = FUNCS["yaml_multiline"]("alpha, beta, gamma")
+        lines = result.splitlines()
+        assert len(lines) == 3
+
+    def test_with_indent(self) -> None:
+        result = FUNCS["yaml_multiline"]("a, b", "2")
+        assert all(line.startswith("  ") for line in result.splitlines())

--- a/tests/test_tyranno_functions.py
+++ b/tests/test_tyranno_functions.py
@@ -4,130 +4,188 @@
 
 """Unit tests for the Tyranno function registry."""
 
-import pytest
-
-from tyranno_sandbox.tyranno_functions import FUNCS, SOURCE_FUNCS
+from tyranno_sandbox.tyranno_functions import (
+    from_json,
+    from_yaml,
+    join,
+    now_local,
+    now_utc,
+    pep440,
+    pep440_minor,
+    semver,
+    sort,
+    timestamp,
+    yaml,
+    yaml_multiline,
+)
 
 
 class TestYamlFunc:
     def test_plain_string(self) -> None:
-        assert FUNCS["yaml"]("hello world") == "hello world"
+        assert yaml("hello world") == "hello world"
 
     def test_string_needing_quotes(self) -> None:
-        result = FUNCS["yaml"]("with: colon")
+        result = yaml("with: colon")
         assert result == "'with: colon'"
 
     def test_boolean_string_gets_quoted(self) -> None:
-        result = FUNCS["yaml"]("true")
+        result = yaml("true")
         assert result == "'true'"
 
     def test_url_is_valid_yaml_scalar(self) -> None:
-        result = FUNCS["yaml"]("https://example.com")
+        result = yaml("https://example.com")
         assert "example.com" in result
 
     def test_list_becomes_block_sequence(self) -> None:
-        result = FUNCS["yaml"](["alpha", "beta"])
+        result = yaml(["alpha", "beta"])
         assert "- alpha" in result
         assert "- beta" in result
 
     def test_integer(self) -> None:
-        result = FUNCS["yaml"](42)
+        result = yaml(42)
         assert result == "42"
 
 
 class TestFromYaml:
     def test_parses_scalar(self) -> None:
-        assert FUNCS["from_yaml"]("hello") == "hello"
+        assert from_yaml("hello") == "hello"
 
     def test_parses_sequence(self) -> None:
-        result = FUNCS["from_yaml"]("- a\n- b")
+        result = from_yaml("- a\n- b")
         assert result == ["a", "b"]
 
     def test_roundtrip(self) -> None:
         original = ["ci/cd", "python"]
-        dumped = FUNCS["yaml"](original)
-        parsed = FUNCS["from_yaml"](dumped)
+        dumped = yaml(original)
+        parsed = from_yaml(dumped)
         assert parsed == original
 
 
 class TestFromJson:
     def test_parses_object(self) -> None:
-        result = FUNCS["from_json"]('{"key": "value"}')
+        result = from_json('{"key": "value"}')
         assert result == {"key": "value"}
 
     def test_parses_array(self) -> None:
-        result = FUNCS["from_json"]('["a", "b"]')
+        result = from_json('["a", "b"]')
         assert result == ["a", "b"]
 
 
-class TestStringFuncs:
-    def test_lower(self) -> None:
-        assert FUNCS["lower"]("Hello World") == "hello world"
+class TestPep440:
+    def test_minor_version(self) -> None:
+        result = pep440("1.2.3")
+        assert result["minor_version"] == "1.2"
 
-    def test_upper(self) -> None:
-        assert FUNCS["upper"]("hello") == "HELLO"
+    def test_major_minor_micro(self) -> None:
+        result = pep440("3.14.1")
+        assert result["major"] == 3
+        assert result["minor"] == 14
+        assert result["micro"] == 1
 
-    def test_replace(self) -> None:
-        assert FUNCS["replace"]("foo_bar", "_", "-") == "foo-bar"
+    def test_pre_release(self) -> None:
+        result = pep440("1.0.0a1")
+        assert result["pre_type"] == "a"
+        assert result["pre_number"] == 1
 
-    def test_sort(self) -> None:
-        assert FUNCS["sort"]("banana, apple, cherry") == "apple, banana, cherry"
+    def test_no_pre_release(self) -> None:
+        result = pep440("2.0.0")
+        assert result["pre"] == ""
+        assert result["pre_type"] == ""
 
-    def test_join_default_sep(self) -> None:
-        assert FUNCS["join"]("a, b, c") == "a, b, c"
 
-    def test_join_custom_sep(self) -> None:
-        assert FUNCS["join"]("a, b, c", " | ") == "a | b | c"
+class TestPep440Minor:
+    def test_strips_patch(self) -> None:
+        assert pep440_minor("1.2.3") == "1.2"
 
-    def test_spdx_license(self) -> None:
-        assert FUNCS["spdx_license"]("Apache-2.0") == "Apache-2.0"
+    def test_large_minor(self) -> None:
+        assert pep440_minor("3.14.0") == "3.14"
 
-    def test_pep440_minor(self) -> None:
-        assert FUNCS["pep440_minor"]("1.2.3") == "1.2"
 
-    def test_pep440_minor_strips_patch(self) -> None:
-        assert FUNCS["pep440_minor"]("3.14.0") == "3.14"
+class TestSemver:
+    def test_major_minor_patch(self) -> None:
+        result = semver("1.2.3")
+        assert result["major"] == 1
+        assert result["minor"] == 2
+        assert result["patch"] == 3
+
+    def test_minor_version_string(self) -> None:
+        result = semver("2.5.0")
+        assert result["minor_version"] == "2.5"
+
+    def test_pre_release(self) -> None:
+        result = semver("1.0.0-alpha.1")
+        assert result["pre"] == "alpha.1"
+
+    def test_no_pre_release(self) -> None:
+        result = semver("1.2.3")
+        assert result["pre"] == ""
+
+
+class TestTimestamp:
+    def test_parses_iso_datetime(self) -> None:
+        result = timestamp("2025-06-15T10:30:00+00:00")
+        assert result["year"] == 2025
+        assert result["month"] == 6
+        assert result["day"] == 15
+
+    def test_unix_time(self) -> None:
+        result = timestamp("2025-01-01T00:00:00+00:00")
+        assert result["unix_time"] == 1735689600
 
 
 class TestSourceFuncs:
-    def test_now_utc_returns_datetime(self) -> None:
-        import datetime
+    def test_now_utc_returns_time_dict(self) -> None:
+        result = now_utc()
+        assert isinstance(result, dict)
+        assert "year" in result
+        assert "unix_time" in result
 
-        result = SOURCE_FUNCS["now_utc"]()
-        assert isinstance(result, datetime.datetime)
-        assert result.tzinfo is not None
-
-    def test_now_local_returns_datetime(self) -> None:
-        import datetime
-
-        result = SOURCE_FUNCS["now_local"]()
-        assert isinstance(result, datetime.datetime)
+    def test_now_local_returns_time_dict(self) -> None:
+        result = now_local()
+        assert isinstance(result, dict)
+        assert "year" in result
 
     def test_now_utc_is_startup_time(self) -> None:
         from tyranno_sandbox._global_vars import STARTUP
 
-        result = SOURCE_FUNCS["now_utc"]()
-        assert result == STARTUP.utc
+        result = now_utc()
+        assert result["unix_time"] == int(STARTUP.utc.timestamp())
 
     def test_now_utc_year_is_reasonable(self) -> None:
-        result = SOURCE_FUNCS["now_utc"]()
-        assert 2020 <= result.year <= 2100
+        result = now_utc()
+        assert 2020 <= result["year"] <= 2100
 
-    def test_now_utc_and_now_local_differ_only_by_timezone(self) -> None:
-        utc = SOURCE_FUNCS["now_utc"]()
-        local = SOURCE_FUNCS["now_local"]()
-        import datetime
-
-        diff = abs((utc - local.astimezone(datetime.timezone.utc)).total_seconds())
-        assert diff < 1  # same instant
+    def test_now_utc_and_now_local_same_instant(self) -> None:
+        utc = now_utc()
+        local = now_local()
+        assert utc["unix_time"] == local["unix_time"]
 
 
 class TestYamlMultiline:
     def test_basic(self) -> None:
-        result = FUNCS["yaml_multiline"]("alpha, beta, gamma")
-        lines = result.splitlines()
-        assert len(lines) == 3
+        assert yaml_multiline("alpha, beta, gamma") == "alpha\nbeta\ngamma"
 
     def test_with_indent(self) -> None:
-        result = FUNCS["yaml_multiline"]("a, b", "2")
-        assert all(line.startswith("  ") for line in result.splitlines())
+        assert yaml_multiline("a, b", 2) == "  a\n  b"
+
+    def test_list_input(self) -> None:
+        assert yaml_multiline(["x", "y"]) == "x\ny"
+
+
+class TestSort:
+    def test_csv_string(self) -> None:
+        assert sort("banana, apple, cherry") == "apple, banana, cherry"
+
+    def test_list_input(self) -> None:
+        assert sort(["gamma", "alpha", "beta"]) == "alpha, beta, gamma"
+
+
+class TestJoin:
+    def test_default_sep(self) -> None:
+        assert join("a, b, c") == "a, b, c"
+
+    def test_custom_sep(self) -> None:
+        assert join("a, b, c", " | ") == "a | b | c"
+
+    def test_list_input(self) -> None:
+        assert join(["x", "y", "z"], "-") == "x-y-z"

--- a/uv.lock
+++ b/uv.lock
@@ -1260,7 +1260,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.26.6"
+version = "0.26.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -1268,9 +1268,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/8a/8dc5733b8939e7f1a71173091a6e27a1658345edbff548a0bf3f5bb26173/typer-0.26.6.tar.gz", hash = "sha256:cdbc160fe7e795b835fb6016419494a521a67bfb86b9476a1ccd0e7727d3ae5b", size = 201595, upload-time = "2026-06-02T13:47:50.536Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/c7/519138260db5e2fe03a509bf9e8ef6af9a514d3565c8fa74fc4fededbae1/typer-0.26.6-py3-none-any.whl", hash = "sha256:49f96d9ee5730cef607bbe155042f40b41fa4c0d0dec04990d580837493805be", size = 122464, upload-time = "2026-06-02T13:47:51.768Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1306,6 +1306,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pathspec" },
     { name = "platformdirs" },
+    { name = "pyyaml" },
     { name = "semver" },
     { name = "tzdata", marker = "sys_platform != 'linux'" },
 ]
@@ -1371,6 +1372,7 @@ requires-dist = [
     { name = "pathspec", specifier = ">=1.1" },
     { name = "platformdirs", specifier = ">=4.10" },
     { name = "pydantic", marker = "extra == 'server'", specifier = ">=2.13" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "rfc9457", marker = "extra == 'server'", specifier = ">=0.4" },
     { name = "semver", specifier = ">=3.0.4" },
     { name = "starlette-compress", marker = "python_full_version < '3.14' and extra == 'server'", specifier = ">=1.7" },


### PR DESCRIPTION
## Summary

- Rewrote `sync.py` with a clean state machine that processes `::tyranno::` comment blocks, consuming N content lines after N consecutive marker lines and replacing them with evaluated expressions
- Rewrote `context.py` expression evaluator supporting pipe syntax (`project.keywords | yaml(@)`), dot-chained syntax (`project.description.yaml(@)`), and standalone calls (`now_utc().year`); fixed `$<< >>` delimiter regex and all prefix normalizations (`.key` → `tool.tyranno.data.key`, `$.key` → pyproject root)
- Fixed `dot_tree.py` recursive value validation so nested TOML structures (dicts/lists) don't raise `TypeError`
- Fixed `_global_vars.py`: added missing `GlobalVarsFactory` base class, corrected `FORCE_COLOR`/`NO_COLOR` logic, removed stale `roaming` kwarg dropped by `platformdirs`
- Fixed `__main__.py`: wired up the `sync` command, made `LogLevel` inherit from `int` for comparisons, corrected log-level index calculation, removed unsupported `encoding` kwarg from `logger.add()`
- Fixed `tests/__init__.py`: added missing `import os`

## Test plan

- [ ] `uv run python -m pytest tests/ --no-cov` — all 5 tests pass
- [ ] `uv run tyranno-sandbox --dry-run -v sync` — processes all target files, reports 2 changed lines in `.github/project.yaml` (description text and YAML-quoted URL)
- [ ] `uv run tyranno-sandbox --help` and `uv run tyranno-sandbox sync --help` — help text renders correctly

https://claude.ai/code/session_01LdMrTnQp8jDhWmV5mJLFnt

---
_Generated by [Claude Code](https://claude.ai/code/session_01LdMrTnQp8jDhWmV5mJLFnt)_